### PR TITLE
Fixes issues with folders that have spaces

### DIFF
--- a/src/main/java/helpers/GetResource.java
+++ b/src/main/java/helpers/GetResource.java
@@ -1,0 +1,16 @@
+package helpers;
+import java.net.URLDecoder;
+
+public class GetResource {
+
+    static public String getFile(String image_name) {
+        try {
+            String path =  URLDecoder.decode(GetResource.class.getResource(image_name).getFile(), "UTF-8");
+            return path;
+        } catch (Exception e) {
+            System.out.println(String.format("Error Getting Image: %s", image_name, GetResource.class.getResource(image_name)));
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/src/main/java/t01sandbox/SandboxIJ1.java
+++ b/src/main/java/t01sandbox/SandboxIJ1.java
@@ -2,6 +2,7 @@ package t01sandbox;
 
 import java.io.IOException;
 
+import helpers.GetResource;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.display.imagej.ImageJFunctions;
@@ -26,7 +27,7 @@ public class SandboxIJ1
 		new ImageJ();
 
 		// open an ImageJ1 ImagePlus
-		final ImagePlus imp = IJ.openImage( SandboxIJ1.class.getResource( "/clown.png" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile( "/clown.png" ) );
 //		final ImagePlus imp = IJ.openImage( "https://imagej.net/images/clown.png" );
 
 		// wrap it as an ImgLib2 img

--- a/src/main/java/t01sandbox/SandboxIJ2.java
+++ b/src/main/java/t01sandbox/SandboxIJ2.java
@@ -2,6 +2,7 @@ package t01sandbox;
 
 import java.io.IOException;
 
+import helpers.GetResource;
 import net.imagej.Dataset;
 import net.imagej.ImageJ;
 import net.imglib2.img.Img;
@@ -18,7 +19,7 @@ public class SandboxIJ2
 		// show the ImageJ window
 		ij.ui().showUI();
 
-		final Img< ? > img = ij.scifio().datasetIO().open( SandboxIJ2.class.getResource( "/clown.png" ).getFile() );
+		final Img< ? > img = ij.scifio().datasetIO().open( GetResource.getFile("clown.png" ) );
 //		final Img< ? > img = ij.scifio().datasetIO().open( "https://imagej.net/images/clown.png" );
 
 		/*

--- a/src/main/java/t01sandbox/SandboxSimplifiedIO.java
+++ b/src/main/java/t01sandbox/SandboxSimplifiedIO.java
@@ -2,6 +2,7 @@ package t01sandbox;
 
 import java.io.IOException;
 
+import helpers.GetResource;
 import net.imagej.ImageJ;
 import net.imglib2.img.Img;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
@@ -17,7 +18,7 @@ public class SandboxSimplifiedIO
 		// show the ImageJ window
 		ij.ui().showUI();
 
-		final Img< UnsignedByteType > img = SimplifiedIO.openImage( SandboxIJ1.class.getResource( "/clown.png" ).getFile(), new UnsignedByteType() );
+		final Img< UnsignedByteType > img = SimplifiedIO.openImage( GetResource.getFile("clown.png" ), new UnsignedByteType() );
 //		final Img< UnsignedByteType > img = SimplifiedIO.openImage( "https://imagej.net/images/clown.png", new UnsignedByteType() );
 
 		// show the img

--- a/src/main/java/t02accessors/T02E05Copy.java
+++ b/src/main/java/t02accessors/T02E05Copy.java
@@ -2,6 +2,7 @@ package t02accessors;
 
 import java.io.IOException;
 
+import helpers.GetResource;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
@@ -23,7 +24,7 @@ public class T02E05Copy
 {
 	public static void main( final String[] args ) throws IOException
 	{
-		final ImagePlus imp = IJ.openImage( T02E05Copy.class.getResource( "/clown.png" ).getFile() );
+		final ImagePlus imp = IJ.openImage(GetResource.getFile("clown.png" ) );
 //		final ImagePlus imp = IJ.openImage( "https://imagej.net/images/clown.png" );
 		final Img< ARGBType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img, "img" );

--- a/src/main/java/t03types/T03E02GenericCopy.java
+++ b/src/main/java/t03types/T03E02GenericCopy.java
@@ -2,6 +2,7 @@ package t03types;
 
 import java.io.IOException;
 
+import helpers.GetResource;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccess;
 import net.imglib2.img.Img;
@@ -38,7 +39,7 @@ public class T03E02GenericCopy
 
 	public static void main( final String[] args ) throws IOException
 	{
-		final ImagePlus imp = IJ.openImage( T03E02GenericCopy.class.getResource( "/clown.png" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile( "/clown.png" ) );
 //		final ImagePlus imp = IJ.openImage( "https://imagej.net/images/clown.png" );
 		final Img< ARGBType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img, "img" );
@@ -47,7 +48,7 @@ public class T03E02GenericCopy
 		copy( img, copy );
 		ImageJFunctions.show( copy, "copy" );
 
-		final ImagePlus imp2 = IJ.openImage( T03E02GenericCopy.class.getResource( "/blobs.tif" ).getFile() );
+		final ImagePlus imp2 = IJ.openImage( GetResource.getFile( "/blobs.tif" ) );
 //		final ImagePlus imp2 = IJ.openImage( "https://imagej.net/images/blobs.gif" );
 		final Img< UnsignedByteType > img2 = ImageJFunctions.wrap( imp2 );
 		ImageJFunctions.show( img2, "img2" );

--- a/src/main/java/t04accessibles/T04E02Views.java
+++ b/src/main/java/t04accessibles/T04E02Views.java
@@ -1,5 +1,6 @@
 package t04accessibles;
 
+import helpers.GetResource;
 import ij.IJ;
 import ij.ImagePlus;
 import net.imglib2.RandomAccessibleInterval;
@@ -13,7 +14,7 @@ public class T04E02Views
 {
 	public static void main( final String[] args )
 	{
-		final ImagePlus imp = IJ.openImage( T04E02Views.class.getResource( "/clown.png" ).getFile() );
+		final ImagePlus imp = IJ.openImage(GetResource.getFile( "/clown.png" ) );
 		final RandomAccessibleInterval< ARGBType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img, "img" );
 

--- a/src/main/java/t04accessibles/T04E03MoreViews.java
+++ b/src/main/java/t04accessibles/T04E03MoreViews.java
@@ -1,5 +1,6 @@
 package t04accessibles;
 
+import helpers.GetResource;
 import net.imglib2.RandomAccessible;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.display.imagej.ImageJFunctions;
@@ -14,7 +15,7 @@ public class T04E03MoreViews
 {
 	public static void main( final String[] args )
 	{
-		final ImagePlus imp = IJ.openImage( T04E03MoreViews.class.getResource( "/clown.png" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("clown.png" ) );
 		final RandomAccessibleInterval< ARGBType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img, "img" );
 

--- a/src/main/java/t04accessibles/T04E04RealViews.java
+++ b/src/main/java/t04accessibles/T04E04RealViews.java
@@ -1,5 +1,6 @@
 package t04accessibles;
 
+import helpers.GetResource;
 import ij.IJ;
 import ij.ImagePlus;
 import net.imglib2.RandomAccessible;
@@ -17,7 +18,7 @@ public class T04E04RealViews
 {
 	public static void main( final String[] args )
 	{
-		final ImagePlus imp = IJ.openImage( T04E04RealViews.class.getResource( "/clown.png" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("clown.png" ) );
 		final RandomAccessibleInterval< ARGBType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img, "img" );
 

--- a/src/main/java/t04accessibles/T04E05Converters.java
+++ b/src/main/java/t04accessibles/T04E05Converters.java
@@ -1,5 +1,6 @@
 package t04accessibles;
 
+import helpers.GetResource;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
 import net.imglib2.converter.Converters;
@@ -14,7 +15,7 @@ public class T04E05Converters
 {
 	public static void main( final String[] args )
 	{
-		final ImagePlus imp = IJ.openImage( T04E05Converters.class.getResource( "/clown.png" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("clown.png" ) );
 		final RandomAccessibleInterval< ARGBType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img, "img" );
 

--- a/src/main/java/t04accessibles/T04E06EvenMoreViews.java
+++ b/src/main/java/t04accessibles/T04E06EvenMoreViews.java
@@ -1,5 +1,6 @@
 package t04accessibles;
 
+import helpers.GetResource;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converters;
 import net.imglib2.img.display.imagej.ImageJFunctions;
@@ -14,7 +15,7 @@ public class T04E06EvenMoreViews
 {
 	public static void main( final String[] args )
 	{
-		final ImagePlus imp = IJ.openImage( T04E06EvenMoreViews.class.getResource( "/clown.png" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("clown.png" ) );
 		final RandomAccessibleInterval< ARGBType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img, "img" );
 

--- a/src/main/java/t04accessibles/T04E07Smoothing.java
+++ b/src/main/java/t04accessibles/T04E07Smoothing.java
@@ -2,6 +2,7 @@ package t04accessibles;
 
 import java.io.IOException;
 
+import helpers.GetResource;
 import net.imglib2.algorithm.gauss3.Gauss3;
 import net.imglib2.exception.IncompatibleTypeException;
 import net.imglib2.img.Img;
@@ -21,7 +22,7 @@ public class T04E07Smoothing
 {
 	public static void main( final String[] args ) throws IOException, IncompatibleTypeException
 	{
-		final ImagePlus imp = IJ.openImage( T04E07Smoothing.class.getResource( "/clown.png" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("clown.png" ) );
 //		final ImagePlus imp = IJ.openImage( "https://imagej.net/images/clown.png" );
 
 		final Img< ARGBType > input = ImageJFunctions.wrap( imp );

--- a/src/main/java/t04accessibles/T04E08SmoothingAndStacking.java
+++ b/src/main/java/t04accessibles/T04E08SmoothingAndStacking.java
@@ -3,6 +3,7 @@ package t04accessibles;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import helpers.GetResource;
 import net.imglib2.algorithm.gauss3.Gauss3;
 import net.imglib2.exception.IncompatibleTypeException;
 import net.imglib2.img.Img;
@@ -22,7 +23,7 @@ public class T04E08SmoothingAndStacking
 {
 	public static void main( final String[] args ) throws IOException, IncompatibleTypeException
 	{
-		final ImagePlus imp = IJ.openImage( T04E07Smoothing.class.getResource( "/clown.png" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("clown.png" ) );
 //		final ImagePlus imp = IJ.openImage( "https://imagej.net/images/clown.png" );
 
 		final Img< ARGBType > input = ImageJFunctions.wrap( imp );

--- a/src/main/java/t04accessibles/T04E09PartialDerivative.java
+++ b/src/main/java/t04accessibles/T04E09PartialDerivative.java
@@ -1,5 +1,6 @@
 package t04accessibles;
 
+import helpers.GetResource;
 import ij.IJ;
 import ij.ImagePlus;
 import java.io.IOException;
@@ -35,7 +36,7 @@ public class T04E09PartialDerivative
 		final ImageJ ij = new ImageJ();
 		ij.ui().showUI();
 
-		final Img< UnsignedByteType > img = SimplifiedIO.openImage( T04E09PartialDerivative.class.getResource( "/t1-head.tif" ).getFile(), new UnsignedByteType() );
+		final Img< UnsignedByteType > img = SimplifiedIO.openImage( GetResource.getFile("/t1-head.tif" ), new UnsignedByteType() );
 		final Img< DoubleType > output = new ArrayImgFactory<>( new DoubleType() ).create( img );
 
 		LoopBuilder.setImages(

--- a/src/main/java/t05labelings/T05E03ObjectSegmentation1.java
+++ b/src/main/java/t05labelings/T05E03ObjectSegmentation1.java
@@ -2,6 +2,7 @@ package t05labelings;
 
 import java.util.Iterator;
 
+import helpers.GetResource;
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
@@ -23,7 +24,7 @@ public class T05E03ObjectSegmentation1
 		new ImageJ();
 
 		// Load the image to segment.
-		final ImagePlus imp = IJ.openImage( T05E03ObjectSegmentation1.class.getResource( "/blobs.tif" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("blobs.tif" ) );
 		final Img< UnsignedByteType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img );
 

--- a/src/main/java/t05labelings/T05E04ObjectSegmentation2.java
+++ b/src/main/java/t05labelings/T05E04ObjectSegmentation2.java
@@ -2,6 +2,7 @@ package t05labelings;
 
 import java.util.Iterator;
 
+import helpers.GetResource;
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
@@ -26,7 +27,7 @@ public class T05E04ObjectSegmentation2
 		new ImageJ();
 
 		// Load the image to segment.
-		final ImagePlus imp = IJ.openImage( T05E04ObjectSegmentation2.class.getResource( "/blobs.tif" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("blobs.tif" ) );
 		final RandomAccessibleInterval< UnsignedByteType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img );
 

--- a/src/main/java/t05labelings/T05E05LabelRegions1.java
+++ b/src/main/java/t05labelings/T05E05LabelRegions1.java
@@ -3,6 +3,7 @@ package t05labelings;
 import java.util.Iterator;
 import java.util.Set;
 
+import helpers.GetResource;
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
@@ -30,7 +31,7 @@ public class T05E05LabelRegions1
 		new ImageJ();
 
 		// Load the image to segment.
-		final ImagePlus imp = IJ.openImage( T05E05LabelRegions1.class.getResource( "/blobs.tif" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("blobs.tif" ) );
 		final RandomAccessibleInterval< UnsignedByteType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img );
 

--- a/src/main/java/t05labelings/T05E06LabelRegions2.java
+++ b/src/main/java/t05labelings/T05E06LabelRegions2.java
@@ -3,6 +3,7 @@ package t05labelings;
 import java.util.ArrayList;
 import java.util.Iterator;
 
+import helpers.GetResource;
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
@@ -29,7 +30,7 @@ public class T05E06LabelRegions2
 		new ImageJ();
 
 		// Load the image to segment.
-		final ImagePlus imp = IJ.openImage( T05E06LabelRegions2.class.getResource( "/blobs.tif" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("blobs.tif" ) );
 		final RandomAccessibleInterval< UnsignedByteType > img = ImageJFunctions.wrap( imp );
 		ImageJFunctions.show( img );
 

--- a/src/main/java/t05labelings/T05E07Unfinished.java
+++ b/src/main/java/t05labelings/T05E07Unfinished.java
@@ -3,6 +3,7 @@ package t05labelings;
 import java.awt.Color;
 import java.util.Iterator;
 
+import helpers.GetResource;
 import net.imglib2.Cursor;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.algorithm.labeling.ConnectedComponents;
@@ -36,7 +37,7 @@ public class T05E07Unfinished
 		new ImageJ();
 
 		// Load the image to segment.
-		final ImagePlus imp = IJ.openImage( T05E04ObjectSegmentation2.class.getResource( "/blobs.tif" ).getFile() );
+		final ImagePlus imp = IJ.openImage( GetResource.getFile("blobs.tif" ) );
 		final RandomAccessibleInterval< UnsignedByteType > img = ImageJFunctions.wrap( imp );
 
 		// Segment it based on simple threshold.

--- a/src/main/java/t06neighborhoods/T06E02MaxFilter.java
+++ b/src/main/java/t06neighborhoods/T06E02MaxFilter.java
@@ -1,5 +1,6 @@
 package t06neighborhoods;
 
+import helpers.GetResource;
 import net.imagej.ImageJ;
 import net.imglib2.RandomAccessible;
 import net.imglib2.algorithm.neighborhood.Neighborhood;
@@ -23,7 +24,7 @@ public class T06E02MaxFilter
 		ij.ui().showUI();
 
 		final Img< UnsignedByteType > img = SimplifiedIO.openImage(
-				T06E02MaxFilter.class.getResource( "/blobs.tif" ).getFile(),
+				GetResource.getFile("blobs.tif" ),
 				new UnsignedByteType() );
 
 		ij.ui().show( "img", img );


### PR DESCRIPTION
In short getResource() returns a URL and the getFile() method does not
escape spaces (and other non-URL characters properly).

This adds a helper class that tries to decode the URL back into a file
path.